### PR TITLE
Add client reference in transaction object

### DIFF
--- a/CodaParser/StatementParsers/TransactionParser.cs
+++ b/CodaParser/StatementParsers/TransactionParser.cs
@@ -66,6 +66,12 @@ namespace CodaParser.StatementParsers
 
             var message = ConstructMessage(lines);
 
+            // Extract client reference when available
+            string clientReference = null;
+            var transactionPart2Line = Helpers.GetFirstLineOfType<TransactionPart2Line>(lines);
+            if (transactionPart2Line != null && transactionPart2Line.ClientReference != null)
+                clientReference = transactionPart2Line.ClientReference.Value;
+
             return new Transaction(
                 account,
                 statementSequence,
@@ -75,6 +81,7 @@ namespace CodaParser.StatementParsers
                 amount,
                 message,
                 structuredMessage,
+                clientReference,
                 sepaDirectDebit);
         }
 

--- a/CodaParser/Statements/Transaction.cs
+++ b/CodaParser/Statements/Transaction.cs
@@ -19,8 +19,9 @@ namespace CodaParser.Statements
         /// <param name="amount">The amount that has been transfered.</param>
         /// <param name="message">A message that is included in the transaction.</param>
         /// <param name="structuredMessage">A structured message.</param>
+        /// <param name="clientReference">The client reference.</param>
         /// <param name="sepaDirectDebit">The sepa direct debit information.</param>
-        public Transaction(AccountOtherParty account, int statementSequence, int transactionSequence, DateTime transactionDate, DateTime valutaDate, decimal amount, string message, string structuredMessage, SepaDirectDebit sepaDirectDebit)
+        public Transaction(AccountOtherParty account, int statementSequence, int transactionSequence, DateTime transactionDate, DateTime valutaDate, decimal amount, string message, string structuredMessage, string clientReference, SepaDirectDebit sepaDirectDebit)
         {
             Account = account;
             StatementSequence = statementSequence;
@@ -30,6 +31,7 @@ namespace CodaParser.Statements
             Amount = amount;
             Message = message;
             StructuredMessage = structuredMessage;
+            ClientReference = clientReference;
             SepaDirectDebit = sepaDirectDebit;
         }
 
@@ -47,6 +49,11 @@ namespace CodaParser.Statements
         /// Gets the included message.
         /// </summary>
         public string Message { get; }
+
+        /// <summary>
+        /// Gets the client reference.
+        /// </summary>
+        public string ClientReference { get; }
 
         /// <summary>
         /// Gets the sepa direct debit information.

--- a/CodaParserTests/ParserTest.cs
+++ b/CodaParserTests/ParserTest.cs
@@ -79,6 +79,7 @@ namespace CodaParserTests
                 Assert.AreNotEqual(default(DateTime), transaction.TransactionDate);
                 Assert.AreNotEqual(default(DateTime), transaction.ValutaDate);
                 Assert.IsNotEmpty(transaction.Message);
+                Assert.AreEqual("54875", transaction.ClientReference);
             }
 
             Assert.AreEqual(1, statement.Transactions[0].TransactionSequence);


### PR DESCRIPTION
Client reference is necessary is some case. Therefore, this code adds it when available.